### PR TITLE
Fix bug where iPad was not selected when it was turned on

### DIFF
--- a/sidecar.applescript
+++ b/sidecar.applescript
@@ -7,6 +7,8 @@ on run {}
 	# It would be better to to it through an API call but I couldn't find anything better than this
 	# Writing this AppleScript script was not fun at all
 	
+	set displayName to "iPadName"
+	set addButtonName to "Add"
 	
 	# Currently Version 15
 	set OSmajor to system attribute "sys1"
@@ -21,40 +23,33 @@ on run {}
 		delay 1
 		set the current pane to pane id "com.apple.Displays-Settings.extension"
 		#reveal anchor "sidecarSection" of current pane
-		
 	end tell
 	
 	
 	
 	tell application "System Events"
+		set addButton to pop up button addButtonName of group 1 of group 2 of splitter group 1 of group 1 of window "Displays" of process "System Settings"
 		
-		
-		repeat until pop up button "Add" of group 1 of group 2 of splitter group 1 of group 1 of window "Displays" of process "System Settings" exists
+		repeat until addButton exists
 		end repeat
-		click pop up button "Add" of group 1 of group 2 of splitter group 1 of group 1 of window "Displays" of process "System Settings"
+		click addButton
 		
-		# Get the iPad name from the parameters
+		set monitorsMenu to menu "Hinzufügen" of addButton
 		
-		repeat until menu item "iPadName" of menu "Add" of pop up button "Add" of group 1 of group 2 of splitter group 1 of group 1 of window "Displays" of application process "System Settings" of application "System Events" exists
+		repeat until menu item displayName of monitorsMenu exists
 		end repeat
-		click menu item "iPadName" of menu "Add" of pop up button "Add" of group 1 of group 2 of splitter group 1 of group 1 of window "Displays" of application process "System Settings" of application "System Events"
 		
+		set lastDisplayNameOccurence to -1
+		set monitorItemsCount to count menu items of monitorsMenu
 		
-		(*
-	-- Idea is to click the last iPad Item, but AppleScript is too primitive to do even that
-	set menuItems to menu items of menu "Add" of pop up button "Add" of group 1 of group 2 of splitter group 1 of group 1 of window "Displays" of application process "System Settings" of application "System Events"
-	set iPadItems to {}
-	
-	-- Loop through the menu items and find all "Vincent’s iPad" items
-	repeat with aMenuItem in iPadItems
-		if name of aMenuItem is "iPadName" then
-			set end of iPadItems to aMenuItem
-		end if
-	end repeat
-	*)
+		repeat with i from 1 to monitorItemsCount
+			set currentItem to menu item i of monitorsMenu
+			if (name of currentItem) is equal to displayName then
+				set lastDisplayNameOccurence to i
+			end if
+		end repeat
 		
-		
-		
+		click menu item lastDisplayNameOccurence of monitorsMenu
 	end tell
 	
 	-- Close the Settings window
@@ -64,3 +59,4 @@ on run {}
 	return 0
 	
 end run
+


### PR DESCRIPTION
When the iPad was turned on, there were two entries with the same name for the iPad. One to connect mouse and keyboard and one to start sidecar. Since the one to connect mouse and keyboard comes first, this option was selected.

With this change, the script selects the last entry with a matching name.